### PR TITLE
Artwork

### DIFF
--- a/src/app/(private)/(sidebar)/artwork/table-columns.tsx
+++ b/src/app/(private)/(sidebar)/artwork/table-columns.tsx
@@ -239,7 +239,7 @@ export const getArtworkColumns = ({
     ),
     cell: ({ row }) => (
       <div className="text-muted-foreground">
-        ${row.original.price.toFixed(2)}
+        {row.original.price.toFixed(2)} ₫
       </div>
     ),
   },


### PR DESCRIPTION
This pull request makes a small adjustment to the `getArtworkColumns` function in `artwork/table-columns.tsx`. The change updates the price display format to include the Vietnamese đồng (₫) currency symbol.

* [`src/app/(private)/(sidebar)/artwork/table-columns.tsx`](diffhunk://#diff-a584b4a1affea09b21ca781151fd782bae43ccafb4e2e6a312a7016f1ca8c14aL242-R242): Modified the `cell` rendering logic to append the ₫ symbol after the price value.